### PR TITLE
LPS-102794 - Fix blockquote pasting

### DIFF
--- a/src/assets/sass/components/ae-editable/skin.scss
+++ b/src/assets/sass/components/ae-editable/skin.scss
@@ -1,7 +1,26 @@
 .ae-editable {
-    @include selection {
-        background: $selection-bg-color !important;
-        color: $selection-color;
-        text-shadow: $selection-shadow;
+	@include selection {
+		background: $selection-bg-color !important;
+		color: $selection-color;
+		text-shadow: $selection-shadow;
     }
+
+	blockquote {
+		padding: 2px 0;
+		border-style: solid;
+		border-color: #ccc;
+		border-width: 0;
+	}
+
+	&.cke_contents_ltr blockquote {
+		padding-left: 20px;
+		padding-right: 8px;
+		border-left-width: 5px;
+	}
+
+	&.cke_contents_rtl blockquote {
+		padding-left: 8px;
+		padding-right: 20px;
+		border-right-width: 5px;
+	}
 }


### PR DESCRIPTION
Hey Julien, I've tested this in the Alloy Editor Demo, from my investigation the pasting was working half-way, it would paste a `blockquote` but there weren't any styles that made it look different.
I didn't update the versions of alloy-editor as the contributing steps mentioned them in the context of releases and I don't think that's what I'm doing with this PR.