### PR TITLE
LPS-98018 Bug fix

### DIFF
--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -33,7 +33,7 @@ class ButtonAccessibilityImageAlt extends React.Component {
 
 		this.state = {
 			element,
-			imageAlt,
+			imageAlt
 		};
 	}
 
@@ -110,14 +110,14 @@ class ButtonAccessibilityImageAlt extends React.Component {
 	 */
 	_handleAltChange = event => {
 		this.setState({
-			imageAlt: event.target.value,
+			imageAlt: event.target.value
 		});
 
 		this._focusAltInput();
 	};
 
 	/**
-	 * Event attached to al tinput that fires when key is down
+	 * Event attached to alt input that fires when key is down
 	 * This method check that enter key is pushed to update the component´s state
 	 *
 	 * @protected
@@ -155,7 +155,7 @@ class ButtonAccessibilityImageAlt extends React.Component {
 		const imageAlt = this.refs.refAltInput.value;
 
 		this.setState({
-			imageAlt,
+			imageAlt
 		});
 
 		this.state.element.setAttribute('alt', imageAlt);


### PR DESCRIPTION
Hey @julien , please review the code.
------------------------------------------------------------
- Trailing commas in functions don't work in IE
- This solves the issue when the `alt` attribute is changed and saved in Chrome, but doesn't update in IE
- IE also requires the enabling of preference option "Always expand ALT text for images" to be rendered at all. This can be done by following these steps: 
Settings / Internet Options / Advanced / enable "Always expand ALT text for images"